### PR TITLE
Add version and name to package.lock

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,9 +1,12 @@
 {
   "name": "digital-signage",
+  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
+      "name": "digital-signage",
+      "version": "0.1.0",
       "devDependencies": {
         "html-validate": "^8.1.0",
         "jsdom": "^22.1.0",

--- a/package.json
+++ b/package.json
@@ -1,4 +1,6 @@
 {
+  "name": "digital-signage",
+  "version": "0.1.0",
   "devDependencies": {
     "html-validate": "^8.1.0",
     "jsdom": "^22.1.0",


### PR DESCRIPTION
This prevents the package.lock being updated on each machine to the name of the containing folder