### PR TITLE
fix: fix QrCode tests

### DIFF
--- a/frontend/static/widgets/qrcode.mjs
+++ b/frontend/static/widgets/qrcode.mjs
@@ -16,7 +16,9 @@ export class Qrcode extends Widget {
     this.url = url
   }
 
-  static showError (canvas) {
+  static showError (canvas, error) {
+    console.error('An error occurred with the QRCode:', error.message)
+    canvas.classList.add('error')
     const imageElement = document.createElement('img')
     imageElement.src = '/static/QRcode_failure.jpg'
 
@@ -38,15 +40,13 @@ export class Qrcode extends Widget {
         height: 100
       }
 
-      QRCode.toCanvas(canvas, null, options, function (error) {
+      QRCode.toCanvas(canvas, this.url, options, function (error) {
         if (error) {
-          console.error('An error occurred with the QRCode:', error.message)
-          Qrcode.showError(canvas)
+          Qrcode.showError(canvas, error)
         }
       })
     } catch (error) {
-      console.error('An error occurred with the QRCode:', error.message)
-      Qrcode.showError(canvas)
+      Qrcode.showError(canvas, error)
     }
     return qrCodeContainer
   }

--- a/frontend/test/test_free_form_content.mjs
+++ b/frontend/test/test_free_form_content.mjs
@@ -233,6 +233,7 @@ export function checkRenderedQrcode (out, expectedUrl) {
   assert.equal(a.tagName, 'A')
   const aa = a.children[0]
   assert.equal(aa.tagName, 'CANVAS')
+  assert(!aa.classList.contains('error'))
 }
 
 export function checkRenderedQrcodeCaptionedTitleBody (


### PR DESCRIPTION
Fixes #91. I think I introduced the reason the QrCode was broken, but these tests should properly fail instead of passing silently.